### PR TITLE
feat: make issue template for calls

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_call.md
+++ b/.github/ISSUE_TEMPLATE/design_call.md
@@ -14,7 +14,7 @@ Timezone: UTC
 Duration: 1h 30m
 ```
 
-[Incredibly well-designed event cover image]
+[Incredibly well-designed event cover image, see other call issues for inspiration but feel free to put your own touch on it. Landscape formats work best.]
 
 ### Agenda
 

--- a/.github/ISSUE_TEMPLATE/design_call.md
+++ b/.github/ISSUE_TEMPLATE/design_call.md
@@ -1,0 +1,33 @@
+---
+name: Community or working group call
+about: Bitcoin Design community call or design sessions
+title: '... Design Call #0'
+labels: 'call'
+assignees: ''
+
+---
+
+```meta
+Date: 2020-MM-DD
+Time: 4:00pm
+Timezone: UTC
+Duration: 1h 30m
+```
+
+[Incredibly well-designed event cover image]
+
+### Agenda
+
+1. ...
+
+### Check your timezone
+
+[LINK FOR TIMEZONE e.g. from everytimezone.com]
+
+### Join the call
+
+[LINK FOR CALL]
+
+### Calendar invite
+
+[LINK TO CALENDAR INVITE]


### PR DESCRIPTION
### Problem
Community members are proposing more types of design calls. For example recently started was Design Reviews, as well as the already established Bitcoin Core GUI calls. Hopefully this behaviour continues, and we see more calls being proposed.

- Working group/project calls as well as the monthly community calls should be posted on github as [issues](https://github.com/BitcoinDesign/Meta/issues?q=is%3Aissue+label%3Acall+)
- Formatting should be consistent so it's easy to at a glance get the event details.
- It may not be clear to designers new to github and markdown how to do this formatting.

### Solution
- Use github issue templates to help enforce the format for call issues

### Result
- Created a design_call issue template which automatically labels the issue as call
- Some initial content is provided as guidance

<img width="488" alt="Screenshot 2020-09-22 at 01 18 21" src="https://user-images.githubusercontent.com/183140/93827261-95072980-fc71-11ea-9779-b4597fc01532.png">

<img width="525" alt="Screenshot 2020-09-22 at 01 20 13" src="https://user-images.githubusercontent.com/183140/93827387-d39ce400-fc71-11ea-8bc6-58f75932aef8.png">
