### PR TITLE
Add link to newsletter on Substack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Community activity is fluid, but here are a few important starting points:
 ## How to get involved in the community
 
 1. [Join the community on Slack](https://join.slack.com/t/bitcoindesign/shared_invite/zt-gytq2snl-4TEWJOTKrXRCB4YLBoDunA)
-2. Read up on our [project life cycle](Projects.md)
-3. Browse [issues](https://github.com/BitcoinDesign/Meta/issues) for upcoming calls and discussions around processes and coordination
+2. [Subscribe to the newsletter](https://bitcoindesign.substack.com) to stay up-to-date
+3. Read up on our [project life cycle](Projects.md)
+4. Browse [issues](https://github.com/BitcoinDesign/Meta/issues) for upcoming calls and discussions around processes and coordination
 
 ## How to get involved in projects
 


### PR DESCRIPTION
Adds a link to a newsletter published via Substack and therefore makes the newsletter "official". Below is the reason why this is something we may want.

**Problem**
As the community grows to over 600 in Slack, it becomes more difficult to keep track of what is happening across the 19 channels. Several members have already stated that it is hard to keep up.

**Solution**
A newsletter that gets sent out every 2 or 3 weeks as a convenient way for members (and non-members) to stay up-to-date with minimal effort.

We can expand on the [agenda we already create](https://docs.google.com/document/d/1Iib9fM9mVMlNFyG0AaUHa0XzsrGh9LVoErpKA7xwreY/edit?usp=sharing) for community calls, which provides a summary of what happened in the past 3 weeks. This reduces the overall effort as no new content needs to be created. We really just republish something we already do in another format.

**Content**
The newsletter should primarily consist of bullets with short description and plenty of links. It should not be overwhelming, but quick to parse and pick out updates the reader finds personally relevant.

**Ideas:**

- Calls that happened, and upcoming ones
- Hot topics/conversations in Slack
- Project announcements and updates
- Open issues that need attention
- Issues that were closed/finalized
- Relevant external events

**Newsletter tool**
https://bitcoindesign.substack.com

This is already set up and ready to go with minimal content and features. Tracking settings are disabled for the newsletter for privacy reasons, but Substack may still have their own tracking. I am the current "Owner" and @ConorOkus and @johnsBeharry are "Admins".

**Authors**
Conor, Johns, and Christoph to start, who also put this proposal together.

The first issue would likely go out early next week.

So that's the idea. What do you think? How can it be improved?
