### PR TITLE
Add Domains.md to describe rules around domain maintainer role

### DIFF
--- a/Domains.md
+++ b/Domains.md
@@ -36,7 +36,7 @@ The domain maintainer can NOT sell, rent or give the domain away nor accept any 
 ## bitcoin.design
 Maintainer: 
 
-Renewal date: 2021-06-27
+Renewal date: 2021-06-27T23:59:59.0Z
 
 DNS records:
 

--- a/Domains.md
+++ b/Domains.md
@@ -1,27 +1,25 @@
-# Domains
+# Community domains
 
-This document sets out rules on community domains and the responsibilities and expectations of anyone that maintains and manages the domain settings of official domains used by the Bitcoin Design community. 
-The community
+This document sets out rules for community domains and the responsibilities and expectations of anyone that maintains and manages the domain settings of official domains used by the Bitcoin Design community. Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to;
+
+- bitcoin.design
+
+## The community
 The Bitcoin Design community, defined as; 
 
 *“The active members of the Slack workspace at bitcoindesign.slack.com, represented in rough-consensus by the maintainers of the BitcoinDesign Github organization at github.com/bitcoindesign”.*
 
-## Community domains
-Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to;
-
-- bitcoin.design
-
-## Domain ownership
+## Ownership
 A community domain shall be considered owned by the Bitcoin Design community.
 The role of domain maintainer does not imply any ownership of the domain. 
 
-## Domain registration and payments
+## Registration and payments
 The community will pay for, or solicit donations to pay for the long term registration of the community domain(s). 
 
-## Domain maintainer
-The domain maintainer needs to enact the will of the community and should be strongly disincentivized to act in their own interest. They are NOT allowed to change the domain settings in any way without the approval from the community as set out in domain changes. The domain maintainer is selected from the community github maintainers, should be an active contributor at the time of selection and should notify the community if they no longer wish to be a maintainer or are planning to leave their active role in the community.
+## Maintainer
+A domain maintainer needs to enact the will of the community and should be strongly disincentivized to act in their own interest. They are NOT allowed to change the domain settings in any way without the approval from the community as set out in domain changes. The domain maintainer is selected from the community github maintainers, should be an active contributor at the time of selection and should notify the community if they no longer wish to be a maintainer or are planning to leave their active role in the community.
 
-## Domain changes
+## Changes
 The domain maintainer will not make any changes to the domain (including pointing it to other content than hosted by the github.com/bitcoindesign repositories) without the consent of the community. To make a change, a community github maintainer needs to propose a change;
 
 - Create a pull request with a clear description and rationale for the change in the bitcoindesign/meta repository.
@@ -33,6 +31,7 @@ The domain maintainer will not make any changes to the domain (including pointin
 The domain maintainer can NOT sell, rent or give the domain away nor accept any form of payment for proposing or changing domain settings. The domain maintenance authority can only be handed over to another community maintainer through the domain change process outlined above.
 
 ---
+# Domain information
 
 ## bitcoin.design
 Maintainer: 

--- a/Domains.md
+++ b/Domains.md
@@ -35,7 +35,7 @@ The domain maintainer can NOT sell, rent or give the domain away nor accept any 
 # Domain information
 
 ## bitcoin.design
-Maintainer: 
+Maintainer: @gbks, as [decided](https://github.com/BitcoinDesign/Guide/pull/21#issuecomment-738131599)
 
 Expiry date: 2021-06-27T23:59:59.0Z
 

--- a/Domains.md
+++ b/Domains.md
@@ -36,7 +36,9 @@ The domain maintainer can NOT sell, rent or give the domain away nor accept any 
 
 ## bitcoin.design
 Maintainer: 
+
 Renewal date:
+
 DNS records:
 
 

--- a/Domains.md
+++ b/Domains.md
@@ -5,7 +5,8 @@ The community
 The Bitcoin Design community, defined as; 
 
 *“The active members of the Slack workspace at bitcoindesign.slack.com, represented in rough-consensus by the maintainers of the BitcoinDesign Github organization at github.com/bitcoindesign”.
-Community domains
+
+## Community domains
 Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to;*
 
 - bitcoin.design

--- a/Domains.md
+++ b/Domains.md
@@ -15,7 +15,7 @@ A community domain shall be considered owned by the Bitcoin Design community.
 The role of domain maintainer does not imply any ownership of the domain. 
 
 ## Registration and payments
-The community will pay for, or solicit donations to pay for the long term registration of the community domain(s). 
+The community will pay for, or solicit donations to pay for the long term registration of the community domain(s). The current yearly fees are $49.88 for bitcoin.design, and $12 plus tax for bitcoindesigners.org.
 
 ## Maintainer
 A domain maintainer needs to enact the will of the community and should be strongly disincentivized to act in their own interest. They are NOT allowed to change the domain settings in any way without the approval from the community as set out in domain changes. The domain maintainer is selected from the community github maintainers, should be an active contributor at the time of selection and should notify the community if they no longer wish to be a maintainer or are planning to leave their active role in the community.

--- a/Domains.md
+++ b/Domains.md
@@ -1,4 +1,4 @@
-#Domains
+# Domains
 
 This document sets out rules on community domains and the responsibilities and expectations of anyone that maintains and manages the domain settings of official domains used by the Bitcoin Design community. 
 The community
@@ -10,17 +10,17 @@ Community domains are used to promote and host content that the community has cr
 
 - bitcoin.design
 
-##Domain ownership
+## Domain ownership
 A community domain shall be considered owned by the Bitcoin Design community.
 The role of domain maintainer does not imply any ownership of the domain. 
 
-##Domain registration and payments
+## Domain registration and payments
 The community will pay for, or solicit donations to pay for the long term registration of the community domain(s). 
 
-##Domain maintainer
+## Domain maintainer
 The domain maintainer needs to enact the will of the community and should be strongly disincentivized to act in their own interest. They are NOT allowed to change the domain settings in any way without the approval from the community as set out in domain changes. The domain maintainer is selected from the community github maintainers, should be an active contributor at the time of selection and should notify the community if they no longer wish to be a maintainer or are planning to leave their active role in the community.
 
-##Domain changes
+## Domain changes
 The domain maintainer will not make any changes to the domain (including pointing it to other content than hosted by the github.com/bitcoindesign repositories) without the consent of the community. To make a change, a community github maintainer needs to propose a change;
 
 - Create a pull request with a clear description and rationale for the change in the bitcoindesign/meta repository.
@@ -33,7 +33,7 @@ The domain maintainer can NOT sell, rent or give the domain away nor accept any 
 
 ---
 
-##bitcoin.design
+## bitcoin.design
 Maintainer: 
 Renewal date:
 DNS records:

--- a/Domains.md
+++ b/Domains.md
@@ -1,0 +1,45 @@
+#Domains
+
+This document sets out rules on community domains and the responsibilities and expectations of anyone that maintains and manages the domain settings of official domains used by the Bitcoin Design community. 
+The community
+The Bitcoin Design community, defined as; 
+
+*“The active members of the Slack workspace at bitcoindesign.slack.com, represented in rough-consensus by the maintainers of the BitcoinDesign Github organization at github.com/bitcoindesign”.
+Community domains
+Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to;*
+
+- bitcoin.design
+
+##Domain ownership
+A community domain shall be considered owned by the Bitcoin Design community.
+The role of domain maintainer does not imply any ownership of the domain. 
+
+##Domain registration and payments
+The community will pay for, or solicit donations to pay for the long term registration of the community domain(s). 
+
+##Domain maintainer
+The domain maintainer needs to enact the will of the community and should be strongly disincentivized to act in their own interest. They are NOT allowed to change the domain settings in any way without the approval from the community as set out in domain changes. The domain maintainer is selected from the community github maintainers, should be an active contributor at the time of selection and should notify the community if they no longer wish to be a maintainer or are planning to leave their active role in the community.
+
+##Domain changes
+The domain maintainer will not make any changes to the domain (including pointing it to other content than hosted by the github.com/bitcoindesign repositories) without the consent of the community. To make a change, a community github maintainer needs to propose a change;
+
+- Create a pull request with a clear description and rationale for the change in the bitcoindesign/meta repository.
+- Post a link to the pull request in the #general Slack channel
+- The pull request needs to remain open for at least 30 days and all comments and concern need to be addressed before a decision can me made
+- Decision will be made by rough consensus of the community and the github maintainers
+- The proposing maintainer can participate in the discussion but not resolve the pull request once a decision has been made
+
+The domain maintainer can NOT sell, rent or give the domain away nor accept any form of payment for proposing or changing domain settings. The domain maintenance authority can only be handed over to another community maintainer through the domain change process outlined above.
+
+---
+
+##bitcoin.design
+Maintainer: 
+Renewal date:
+DNS records:
+
+
+
+
+
+

--- a/Domains.md
+++ b/Domains.md
@@ -3,6 +3,7 @@
 This document sets out rules for community domains and the responsibilities and expectations of anyone that maintains and manages the domain settings of official domains used by the Bitcoin Design community. Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to;
 
 - bitcoin.design
+- bitcoindesigners.org
 
 ## The community
 The Bitcoin Design community, defined as; 
@@ -39,7 +40,6 @@ Maintainer:
 Renewal date: 2021-06-27T23:59:59.0Z
 
 DNS records:
-
 
 
 

--- a/Domains.md
+++ b/Domains.md
@@ -4,10 +4,10 @@ This document sets out rules on community domains and the responsibilities and e
 The community
 The Bitcoin Design community, defined as; 
 
-*“The active members of the Slack workspace at bitcoindesign.slack.com, represented in rough-consensus by the maintainers of the BitcoinDesign Github organization at github.com/bitcoindesign”.
+*“The active members of the Slack workspace at bitcoindesign.slack.com, represented in rough-consensus by the maintainers of the BitcoinDesign Github organization at github.com/bitcoindesign”.*
 
 ## Community domains
-Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to;*
+Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to;
 
 - bitcoin.design
 

--- a/Domains.md
+++ b/Domains.md
@@ -23,11 +23,11 @@ A domain maintainer needs to enact the will of the community and should be stron
 ## Changes
 The domain maintainer will not make any changes to the domain (including pointing it to other content than hosted by the github.com/bitcoindesign repositories) without the consent of the community. To make a change, a community github maintainer needs to propose a change;
 
-- Create a pull request with a clear description and rationale for the change in the bitcoindesign/meta repository.
-- Post a link to the pull request in the #general Slack channel
-- The pull request needs to remain open for at least 30 days and all comments and concern need to be addressed before a decision can me made
-- Decision will be made by rough consensus of the community and the github maintainers
-- The proposing maintainer can participate in the discussion but not resolve the pull request once a decision has been made
+1. Create a pull request with a clear description and rationale for the change in the bitcoindesign/meta repository.
+2. Post a link to the pull request in the #general Slack channel
+3. The pull request needs to remain open for at least 30 days and all comments and concern need to be addressed before a decision can me made
+4. Decision will be made by rough consensus of the community and the github maintainers
+5. The proposing maintainer can participate in the discussion but should not be the one to merge the pull request once a decision has been made
 
 The domain maintainer can NOT sell, rent or give the domain away nor accept any form of payment for proposing or changing domain settings. The domain maintenance authority can only be handed over to another community maintainer through the domain change process outlined above.
 
@@ -40,7 +40,6 @@ Maintainer:
 Renewal date: 2021-06-27T23:59:59.0Z
 
 DNS records:
-
 
 
 

--- a/Domains.md
+++ b/Domains.md
@@ -1,6 +1,6 @@
 # Community domains
 
-This document sets out rules for community domains and the responsibilities and expectations of anyone that maintains and manages the domain settings of official domains used by the Bitcoin Design community. Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to;
+This document sets out rules for community domains and the responsibilities and expectations of anyone that maintains and manages the domain settings of official domains used by the Bitcoin Design community. Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories. This currently applies to:
 
 - bitcoin.design
 - bitcoindesigners.org

--- a/Domains.md
+++ b/Domains.md
@@ -36,7 +36,7 @@ The domain maintainer can NOT sell, rent or give the domain away nor accept any 
 ## bitcoin.design
 Maintainer: 
 
-Renewal date:
+Renewal date: 2021-06-27
 
 DNS records:
 

--- a/Domains.md
+++ b/Domains.md
@@ -37,10 +37,16 @@ The domain maintainer can NOT sell, rent or give the domain away nor accept any 
 ## bitcoin.design
 Maintainer: 
 
-Renewal date: 2021-06-27T23:59:59.0Z
+Expiry date: 2021-06-27T23:59:59.0Z
 
 DNS records:
 
+## bitcoindesigners.org
+Maintainer: @moneyball
+
+Expiry date: 2021-06-22T23:09:32Z
+
+DNS records:
 
 
 


### PR DESCRIPTION
This document sets out rules for community domains and the responsibilities and expectations of anyone that maintains and manages the domain settings of official domains used by the Bitcoin Design community. Community domains are used to promote and host content that the community has created and committed to the github.com/bitcoindesign repositories.

Please provide feedback and improvements before we convert this from a Draft to PR