### PR TITLE
Create Collaboration.md

### DIFF
--- a/Collaboration.md
+++ b/Collaboration.md
@@ -153,3 +153,12 @@ Project design process life cycle:
 - We can help designers get more experience and find projects they are passionate about
 - We allow projects to build better products
 - Learnings can flow back into the Bitcoin Design Guide
+
+### How do we prioritize projects?
+
+This is ultimately up to the individuals who are volunteering their time to decide, so the following are simply recommendations:
+
+- [FOSS](https://en.wikipedia.org/wiki/Free_and_open-source_software) over [OSS](https://en.wikipedia.org/wiki/Open-source_software) over [closed source](https://en.wikipedia.org/wiki/Proprietary_software)
+- Non-profit over commercial
+- Self-custodial over custodial
+

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -4,7 +4,7 @@ As we get actively involved in supporting projects, we will probably encounter a
 
 This is not meant to be a strict rule set. Every project is unique, and healthy collaboration requires everyone involved to be sensitive to the projects needs and goals. Our own goal is to support projects and contributors to improve their products and design practices (and not impose our ideas). 
 
-Here are six types of design needs.
+Here are six types of design needs a project may have.
 
 ## #1 Resources & consultation
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -16,7 +16,7 @@ Ways the project can choose to interact with the community:
 1. Engage in Slack conversations to share ideas and get feedback
 1. Participate in a design review session
 
-Our role is to be a helpful partner in providing resources and feedback.
+Our role in this scenario is to be a helpful partner in providing resources and feedback.
 
 ## #2 Solve a specific problem
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -92,7 +92,7 @@ Our goal is clarify what type of design support the project needs, create visibi
 
 ## #6 Adopt a design process
 
-As projects grow and their processes evolve, they may come to a point where they want to improve how they practice design. A designer may already be part of the project, but design contributions have been irregular and unstructured (which is fine for smaller projects).
+As projects grow and their processes evolve, they may come to a point where they want to improve how they practice design and attract designer contributors. A designer may already be part of the project, but design contributions have been irregular and unstructured (which is fine for smaller projects).
 
 Steps we can take:
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -24,7 +24,7 @@ An existing project has identified a problem they would like support with and is
 
 In addition to the options in #1, the team can also create a project brief to start a deeper collaboration. The brief should include the following:
 
-1. Introduce the team, project and design process
+1. Introduce the team, project, its goals, constraints and design process
 1. Explain the issue to work on
 1. Outline ideas for collaboration
 1. Identify next steps with members of the community

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -1,6 +1,6 @@
 # Bitcoin Design Community collaboration playbook
 
-As we get actively involved in supporting projects, we probably encounter a few different types of situations. The goal of this document is to define common types of collaborations, to serve as starting points for new inquiries.
+As we get actively involved in supporting projects, we will probably encounter a few different types of situations. The goal of this document is to define common types of collaborations, to serve as starting points for new inquiries.
 
 This is not meant to be a strict rule set. Every project is unique, and healthy collaboration requires everyone involved to be sensitive to the situation. Our goal is to support projects and contributors to improve their products and design practices (and not impose our ideas). 
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -1,6 +1,6 @@
 # Bitcoin Design Community collaboration playbook
 
-As we get actively involved in supporting projects, we will probably encounter a few different types of situations. The goal of this document is to define common types of collaborations, to serve as starting points for new inquiries.
+The goal of this document is to define common types of collaborations, to serve as starting points for new inquiries.
 
 This is not meant to be a strict rule set. Every project is unique, and healthy collaboration requires everyone involved to be sensitive to the projects needs and goals. Our own goal is to support projects and contributors to improve their products and design practices (and not impose our ideas). 
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -2,7 +2,7 @@
 
 As we get actively involved in supporting projects, we will probably encounter a few different types of situations. The goal of this document is to define common types of collaborations, to serve as starting points for new inquiries.
 
-This is not meant to be a strict rule set. Every project is unique, and healthy collaboration requires everyone involved to be sensitive to the situation. Our goal is to support projects and contributors to improve their products and design practices (and not impose our ideas). 
+This is not meant to be a strict rule set. Every project is unique, and healthy collaboration requires everyone involved to be sensitive to the projects needs and goals. Our own goal is to support projects and contributors to improve their products and design practices (and not impose our ideas). 
 
 Here are six types of design needs.
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -69,7 +69,7 @@ Similar to redesigns, a team of designers (and a project manager) is ideal to ta
 
 ## #5 Find a designer
 
-Some projects want to expand their team by bringing in dedicated designers. As designers are often individual contributors with a unique set of interests, experience and availability, this can often be a longer, moree gradual proces.
+Some projects want to expand their team by bringing in dedicated designers. As designers are often individual contributors with a unique set of interests, experience and availability, this can often be a longer, more gradual process.
 
 Simplified designer life cycle in a project:
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -12,7 +12,7 @@ An existing project is looking for resources and expertise to improve their prod
 
 Ways the project can choose to interact with the community:
 
-1. Review the guide to find a direction or solution
+1. Review the [guide](https://bitcoin.design/guide/) to find a direction or solution
 1. Engage in Slack conversations to share ideas and get feedback
 1. Participate in a design review session
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -1,0 +1,154 @@
+# Bitcoin Design Community collaboration playbook
+
+As we get actively involved in supporting projects, we probably encounter a few different types of situations. The goal of this document is to define common types of collaborations, to serve as starting points for new inquiries.
+
+This is not meant to be a strict rule set. Every project is unique, and healthy collaboration requires everyone involved to be sensitive to the situation. Our goal is to support projects and contributors to improve their products and design practices (and not impose our ideas). 
+
+Here are six types of design needs.
+
+## #1 Resources & consultation
+
+An existing project is looking for resources and expertise to improve their product (and potentially design process).
+
+Ways the project can choose to interact with the community:
+
+1. Review the guide to find a direction or solution
+1. Engage in Slack conversations to share ideas and get feedback
+1. Participate in a design review session
+
+Our role is to be a helpful partner in providing resources and feedback.
+
+## #2 Solve a specific problem
+
+An existing project has identified a problem they would like support with and is looking to the community for help resolving it.
+
+In addition to the options in #1, the team can also create a project brief to start a deeper collaboration. The brief should include the following:
+
+1. Introduce the team, project and design process
+1. Explain the issue to work on
+1. Outline ideas for collaboration
+1. Identify next steps with members of the community
+
+We can share the brief with the community to find contributors.
+
+Solving single problems usually means to work within the current project framework. Bigger discussions around design processes and other improvements can be had, but the main goal is to help resolve the problem that was brought up by the project team.
+
+## #3 Redesign
+
+An existing project is maturing and wants to improve the overall design, which may also means finding a designer and adopting design processes.
+
+The term redesign is often used too quickly. Many times, it is better to systematically improve the existing design than start from scratch. This should be carefully considered.
+
+Steps we can take:
+
+1. Identify goals and vision
+1. Examine the current state of the project
+1. Compare vision to current state
+1. Break down work-to-be-done into manageable parts
+	- Example:
+		1. Refine brand
+		1. Create a UI style guide
+		1. Implement UI style guide (without touching interaction design)
+		1. Revise individual application screens and user flows one-by-one
+1. Prioritize
+	- Consider whether to start with the application or the website
+	- Consider level of effort for each change
+	- Consider availability of contributors
+	- Consider time to adopt new workflows
+1. Plan collaboration
+	- Good idea to start with a design review to present the project and create initial interest
+
+Designers who want to tackle redesigns should ensure they have the availability to regularly contribute for longer periods of time. How much time is required depends on the scope. In addition to designers, having a dedicated project manager available to help with planning and communication is also helpful.
+
+## #4 New project
+
+This is an opportunity to adopt a good design process from the start, beginning with researching product concepts, user research, etc. New projects likely also have other foundations to lay, so designers need to be flexible.
+
+Similar to redesigns, a team of designers (and a project manager) is ideal to tackle new projects. Once the design foundation has been created, that need will shrink.
+
+## #5 Find a designer
+
+Some projects want to expand their team by bringing in dedicated designers. As designers are often individual contributors with a unique set of interests, experience and availability, this can often be a longer, moree gradual proces.
+
+Simplified designer life cycle in a project:
+
+1. Observer
+	- Sees if there are opportunities to contribute
+	- Decides whether contributing is “worth it”
+	- Ideal if there’s an identifiable go-to person to help get started
+1. New contributor
+	- Has identified an area of improvement
+	- Needs guidance on how to contribute (tools, processes...)
+	- Should feel welcome and get satisfaction from contributing
+1. Occasional contributor
+	- Helps when issues arise
+1. Dedicated contributor
+	- Initiates design improvements
+1. Core contributor
+	- Helps shape overall design and design process in a project
+
+Our goal is clarify what type of design support the project needs, create visibility for the "opening", and help onboard designers.
+
+## #6 Adopt a design process
+
+As projects grow and their processes evolve, they may come to a point where they want to improve how they practice design. A designer may already be part of the project, but design contributions have been irregular and unstructured (which is fine for smaller projects).
+
+Steps we can take:
+
+1. Understand current status and design needs (possibly via a design review session)
+1. Understand project workflows by discussing with the team
+1. Recreate application in a design tool as a baseline. This can be done partially, focusing on the areas that are being worked on
+1. Start exploring new changes/features in design first and use those on Github, etc to discuss and make decisions
+1. Build and evolve design system over time
+
+What makes for a good design process:
+
+- Using design to preview and discuss before implementation
+- Having well-organized design files
+- Everybody in the project having access to design files
+- Clear understanding how design moves to implementation
+- Close collaboration between designers and developers during implementation
+- Developers and designers regularly communicating and being comfortable with each others way of working
+- Designs and developers involved (to different degrees at different times) from start to finish
+- Open forum for design conversation
+- Regular user feedback (forums, issues, user testing, analytics, etc)
+- Design decisions based on rationale, not “feelings”
+- Priorities are based on user needs
+- Focus on specific user groups, and a deep understanding of their specific user needs
+- Having a clear problem statement
+
+Project design process life cycle:
+
+1. No design process
+	- Design is typically the outcome of development-driven activity
+1. Loose design contributions
+	- Design suggestions happen but without much structure
+	- Designs done by anyone (good and bad)
+	- Patchy design implementation
+1. Structured design contributions
+	- Design system is getting built
+	- Dedicated communication channels for design
+	- Regular design calls/meetings/discussions 
+1. Mature design process
+	- Design system implemented
+	- Clear process the team is comfortable with
+	- Consistent iteration
+
+---
+
+## Questions and notes
+
+### How do we find projects?
+
+- Conversations within our network
+- Prompts on the [Projects](https://bitcoin.design/projects/) and [Contribute](https://bitcoin.design/contribute/) pages
+- Proactively looking for design needs (Twitter, scanning project issues...) and reaching out to projects
+
+### Why support projects?
+
+- We improve real-world Bitcoin user experiences
+- It allows us to validate our ideas by putting them to the test with real needs
+- We will identify new problems to solve
+- We can help designers get more experience and find projects they are passionate about
+- We allow projects to build better products
+- Learnings can flow back into the Bitcoin Design Guide

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -47,6 +47,7 @@ Steps we can take:
 1. Break down work-to-be-done into manageable parts
 	- Example:
 		1. Refine brand
+		1. User Interface audit
 		1. Create a UI style guide
 		1. Implement UI style guide (without touching interaction design)
 		1. Revise individual application screens and user flows one-by-one

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -31,7 +31,7 @@ In addition to the options in #1, the team can also create a project brief to st
 
 We can share the brief with the community to find contributors.
 
-Solving single problems usually means to work within the current project framework. Bigger discussions around design processes and other improvements can be had, but the main goal is to help resolve the problem that was brought up by the project team.
+Solving single problems usually means to work within the current project framework. Bigger discussions around design processes and other improvements can be had, but the scope of work would be to resolve the specific problem that was brought up by the project team.
 
 ## #3 Redesign
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -63,7 +63,7 @@ Designers who want to tackle redesigns should ensure they have the availability 
 
 ## #4 New project
 
-This is an opportunity to adopt a good design process from the start, beginning with researching product concepts, user research, etc. New projects likely also have other foundations to lay, so designers need to be flexible.
+This is an opportunity to adopt a good design process from the start, beginning with researching product concepts, target audience research, etc. New projects likely also have other foundations to lay, so designers need to be flexible.
 
 Similar to redesigns, a team of designers (and a project manager) is ideal to tackle new projects. Once the design foundation has been created, that need will shrink.
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -8,7 +8,7 @@ Here are six types of design needs a project may have.
 
 ## #1 Resources & consultation
 
-An existing project is looking for resources and expertise to improve their product (and potentially design process).
+An existing project is looking for resources and expertise to improve their product's user experience (and potentially design process).
 
 Ways the project can choose to interact with the community:
 


### PR DESCRIPTION
Adds a page to outline a collaboration playbook to help us better structure involvement with projects. So next time we hear that a project needs design support, we can see which type of collaboration is needed and have a good foundation to kick things off with.

The original Google doc is [here](https://docs.google.com/document/d/1vHHauCktbITPqKApQ5h-i7cFh4W5Y-qqVcpUvlZKKFY/edit?usp=sharing).

What do you think?