### PR TITLE
Update issue template with `UTCTime example`

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_call.md
+++ b/.github/ISSUE_TEMPLATE/design_call.md
@@ -12,7 +12,7 @@ Date: 2021-MM-DD
 Time: 4:00pm
 Timezone: UTC
 Duration: 1h
-UTCTime:
+UTCTime: 2021-MM-DD 16:00 UTC
 ```
 
 [Incredibly well-designed event cover image, see other call issues for inspiration but feel free to put your own touch on it. Landscape formats work best.]


### PR DESCRIPTION
We didn't give an example in the meta for this one, which lead me to schedule 3 calls without knowing the format in which `UTCTime` needs to be filled in. This PR updates the template with an actual example.

