### PR TITLE
Fix date formatting on the event issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_call.md
+++ b/.github/ISSUE_TEMPLATE/design_call.md
@@ -8,8 +8,8 @@ assignees: ''
 ---
 
 ```meta
-Date: 2022-MM-DD
-Time: 4:00pm
+Date: 2022-DD-MM
+Time: 16:00
 Timezone: UTC
 Duration: 1h
 UTCTime: 2022-MM-DD 16:00 UTC
@@ -27,7 +27,7 @@ UTCTime: 2022-MM-DD 16:00 UTC
 
 ### Join the call
 
-[LINK FOR CALL]
+[LINK FOR CALL e.g. https://meet.jit.si/bitcoindesign]
 
 ### Calendar invite
 

--- a/.github/ISSUE_TEMPLATE/design_call.md
+++ b/.github/ISSUE_TEMPLATE/design_call.md
@@ -8,11 +8,8 @@ assignees: ''
 ---
 
 ```meta
-Date: 2022-DD-MM
-Time: 16:00
-Timezone: UTC
-Duration: 1h
 UTCTime: 2022-MM-DD 16:00 UTC
+Duration: 1h
 ```
 
 [Incredibly well-designed event cover image, see other call issues for inspiration but feel free to put your own touch on it. Landscape formats work best.]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     types:
       - opened
       - edited
+      - labeled
 
 jobs:
   create_calendar_from_issues:


### PR DESCRIPTION
The template has been wrong, leading to events not being included in the calendar. Encountered this with three different people who created events in the past 1-2 weeks. Was wondering why I saw the issues but nothing pop up in my calendar tools. Turns out it was due to this template being wrong.