### PR TITLE
Calendar workflow fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,13 @@
 on:
   push:
+    branches:
+      - calendar
   issues:
     types:
       - opened
       - edited
+    branches:
+      - calendar
 
 jobs:
   create_calendar_from_issues:


### PR DESCRIPTION
The workflow is currently run on the "main" branch, but should only run on the "calendar" branch. You can see the failed workflow runs in the "Actions" tab on the repo.

This PR limits the workflow runs to the "calendar" branch (as described [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches)), and hopefully fixes the issue.

Not totally sure why this started happening only recently. My guess it that it's related to GitHub requiring an update to a newer Node version, which I made a few days ago in #437.